### PR TITLE
refactor: remove train method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,39 +14,27 @@ A General purpose k-nearest neighbor classifier algorithm based on the k-d tree 
 
 ## API
 
-### new KNN()
+### new KNN(dataset, predictions[, options])
 
-Constructor that takes no arguments.
-
-__Example__
-
-```js
-var knn = new KNN();
-```
-
-### train(trainingSet, predictions)
-
-Train the KNN model with the given training set, predictions, and some options.
+Instantiates the KNN algorithm with the given dataset, predictions and options.
 
 __Arguments__
 
-* `trainingSet` - A matrix of the training set.
-* `trainingLabels` - An array of value for each case in the training set.
-* `options` - Object with the options for the training.
+* `dataset` - A matrix (2D array) of the dataset.
+* `labels` - An array of labels (one for each sample in the dataset).
+* `options` - Object with the options for the algorithm.
 
 __Options__
 
-* `k` - number of nearest neighbor (Default, number of label + 1).
-* `distance` - distance function for the algorithm, the argument is a function, not an String
-                (by default is euclidean, you can use the functions of this repository [distance](https://github.com/mljs/distance)).
+* `k` - number of nearest neighbors (Default: number of labels + 1).
+* `distance` - distance function for the algorithm (Default: euclidean distance).
 
 __Example__
 
 ```js
-var trainingSet = [[0, 0, 0], [0, 1, 1], [1, 1, 0], [2, 2, 2], [1, 2, 2], [2, 1, 2]];
+var dataset = [[0, 0, 0], [0, 1, 1], [1, 1, 0], [2, 2, 2], [1, 2, 2], [2, 1, 2]];
 var predictions = [0, 0, 0, 1, 1, 1];
-
-knn.train(trainingSet, predictions);
+var knn = new KNN(dataset, predictions);
 ```
 
 ### predict(dataset)

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A General purpose k-nearest neighbor classifier algorithm based on the k-d tree 
 
 ## API
 
-### new KNN(dataset, predictions[, options])
+### new KNN(dataset, labels[, options])
 
-Instantiates the KNN algorithm with the given dataset, predictions and options.
+Instantiates the KNN algorithm.
 
 __Arguments__
 
@@ -37,13 +37,13 @@ var predictions = [0, 0, 0, 1, 1, 1];
 var knn = new KNN(dataset, predictions);
 ```
 
-### predict(dataset)
+### predict(newDataset)
 
 Predict the values of the dataset.
 
 __Arguments__
 
-* `dataset` - A matrix that contains the dataset.
+* `newDataset` - A matrix that contains the dataset.
 
 __Example__
 

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -14,14 +14,4 @@ describe('knn', () => {
         expect(result[0]).toBe(1);
         expect(result[1]).toBe(0);
     });
-
-    it('export and import options', () => {
-        const model = JSON.parse(JSON.stringify(knn));
-
-        const newKNN = KNN.load(model);
-        const result = newKNN.predict([[1.81, 1.81, 1.81], [0.5, 0.5, 0.5]]);
-
-        expect(result[0]).toBe(1);
-        expect(result[1]).toBe(0);
-    });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -4,8 +4,7 @@ describe('knn', () => {
     const cases = [[0, 0, 0], [0, 1, 1], [1, 1, 0], [2, 2, 2], [1, 2, 2], [2, 1, 2]];
     const labels = [0, 0, 0, 1, 1, 1];
 
-    const knn = new KNN();
-    knn.train(cases, labels, {
+    const knn = new KNN(cases, labels, {
         k: 3
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,26 +3,26 @@ import euclideanDistance from 'ml-distance-euclidean';
 
 export default class KNN {
     constructor(dataset, labels, options) {
-            const {
-                distance = euclideanDistance,
-                k = dataset[0].length + 1
-            } = options;
+        const {
+            distance = euclideanDistance,
+            k = dataset[0].length + 1
+        } = options;
 
-            const classes = new Set(labels).size;
+        const classes = new Set(labels).size;
 
-            const points = new Array(dataset.length);
-            for (var i = 0; i < points.length; ++i) {
-                points[i] = dataset[i].slice();
-            }
+        const points = new Array(dataset.length);
+        for (var i = 0; i < points.length; ++i) {
+            points[i] = dataset[i].slice();
+        }
 
-            for (i = 0; i < labels.length; ++i) {
-                points[i].push(labels[i]);
-            }
+        for (i = 0; i < labels.length; ++i) {
+            points[i].push(labels[i]);
+        }
 
-            this.kdTree = new KDTree(points, distance);
-            this.k = k;
-            this.classes = classes;
-            this.distance = distance;
+        this.kdTree = new KDTree(points, distance);
+        this.k = k;
+        this.classes = classes;
+        this.distance = distance;
     }
 
     predict(dataset) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,6 @@ import euclideanDistance from 'ml-distance-euclidean';
 
 export default class KNN {
     constructor(dataset, labels, options) {
-        if (dataset === true) {
-            const model = labels;
-            const distance = options;
-            this.kdTree = new KDTree(model.kdTree, distance);
-            this.k = model.k;
-            this.classes = model.classes;
-            this.distance = distance;
-        } else {
             const {
                 distance = euclideanDistance,
                 k = dataset[0].length + 1
@@ -31,7 +23,6 @@ export default class KNN {
             this.k = k;
             this.classes = classes;
             this.distance = distance;
-        }
     }
 
     predict(dataset) {
@@ -64,27 +55,5 @@ export default class KNN {
         }
 
         return predictedClass;
-    }
-
-    toJSON() {
-        return {
-            name: 'KNN',
-            kdTree: this.kdTree.toJSON(),
-            k: this.k,
-            classes: this.classes,
-            distance: this.distance === euclideanDistance ? 'euclidean' : 'other'
-        };
-    }
-
-    static load(model, distance) {
-        if (model.name !== 'KNN') {
-            throw new RangeError('not a KNN dataset: ' + model.name);
-        }
-        if (model.distance === 'euclidean') {
-            distance = euclideanDistance;
-        } else if (!distance) {
-            throw new TypeError('missing custom distance function');
-        }
-        return new KNN(true, model, distance);
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,53 +1,35 @@
-import {kdTree as kdTree} from './kdTree';
+import {kdTree as KDTree} from './kdTree';
 import euclideanDistance from 'ml-distance-euclidean';
 
 export default class KNN {
-    constructor(reload, model, distance) {
-        if (reload) {
-            this.kdTree = new kdTree(model.kdTree, distance || euclideanDistance);
-            this.k = model.k;
-            this.classes = model.classes;
+    constructor(dataset, labels, options) {
+        if (dataset === true) {
+            this.kdTree = new KDTree(labels.kdTree, options || euclideanDistance);
+            this.k = labels.k;
+            this.classes = labels.classes;
+        } else {
+            const {
+                distance = euclideanDistance,
+                k = dataset[0].length + 1
+            } = options;
+
+            const classes = new Set(labels).size;
+
+            const points = new Array(dataset.length);
+            for (var i = 0; i < points.length; ++i) {
+                points[i] = dataset[i].slice();
+            }
+
+            for (i = 0; i < labels.length; ++i) {
+                points[i].push(labels[i]);
+            }
+
+            this.kdTree = new KDTree(points, distance);
+            this.k = k;
+            this.classes = classes;
         }
     }
 
-    /**
-     * Function that trains the KNN with the given trainingSet and trainingLabels.
-     * The third argument is an object with the following options.
-     *  * distance: that represent the distance function applied (default: euclidean)
-     *  * k: the number of neighboors to take in count for classify (default: number of features + 1)
-     *
-     * @param trainingSet
-     * @param trainingLabels
-     * @param options
-     */
-    train(trainingSet, trainingLabels, options = {}) {
-        const {
-            distance = euclideanDistance,
-            k = trainingSet[0].length + 1
-        } = options;
-
-        const classes = new Set(trainingLabels).size;
-
-        var points = new Array(trainingSet.length);
-        for (var i = 0; i < points.length; ++i) {
-            points[i] = trainingSet[i].slice();
-        }
-
-        for (i = 0; i < trainingLabels.length; ++i) {
-            points[i].push(trainingLabels[i]);
-        }
-
-        this.kdTree = new kdTree(points, distance);
-        this.k = k;
-        this.classes = classes;
-    }
-
-    /**
-     * Function that returns the predictions given the dataset.
-     *
-     * @param dataset
-     * @return {Array}
-     */
     predict(dataset) {
         var predictions = new Array(dataset.length);
         for (var i = 0; i < dataset.length; ++i) {
@@ -57,11 +39,6 @@ export default class KNN {
         return predictions;
     }
 
-    /**
-     * function that returns a prediction for a single case.
-     * @param currentCase
-     * @return {number}
-     */
     getSinglePrediction(currentCase) {
         var nearestPoints = this.kdTree.nearest(currentCase, this.k);
         var pointsPerClass = new Array(this.classes);
@@ -96,7 +73,7 @@ export default class KNN {
 
     static load(model, distance) {
         if (model.name !== 'KNN') {
-            throw new RangeError('not a KNN model: ' + model.name);
+            throw new RangeError('not a KNN dataset: ' + model.name);
         }
         return new KNN(true, model, distance);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ export default class KNN {
         this.kdTree = new KDTree(points, distance);
         this.k = k;
         this.classes = classes;
-        this.distance = distance;
     }
 
     predict(dataset) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,12 @@ import euclideanDistance from 'ml-distance-euclidean';
 export default class KNN {
     constructor(dataset, labels, options) {
         if (dataset === true) {
-            this.kdTree = new KDTree(labels.kdTree, options || euclideanDistance);
-            this.k = labels.k;
-            this.classes = labels.classes;
+            const model = labels;
+            const distance = options;
+            this.kdTree = new KDTree(model.kdTree, distance);
+            this.k = model.k;
+            this.classes = model.classes;
+            this.distance = distance;
         } else {
             const {
                 distance = euclideanDistance,
@@ -27,6 +30,7 @@ export default class KNN {
             this.kdTree = new KDTree(points, distance);
             this.k = k;
             this.classes = classes;
+            this.distance = distance;
         }
     }
 
@@ -67,13 +71,19 @@ export default class KNN {
             name: 'KNN',
             kdTree: this.kdTree.toJSON(),
             k: this.k,
-            classes: this.classes
+            classes: this.classes,
+            distance: this.distance === euclideanDistance ? 'euclidean' : 'other'
         };
     }
 
     static load(model, distance) {
         if (model.name !== 'KNN') {
             throw new RangeError('not a KNN dataset: ' + model.name);
+        }
+        if (model.distance === 'euclidean') {
+            distance = euclideanDistance;
+        } else if (!distance) {
+            throw new TypeError('missing custom distance function');
         }
         return new KNN(true, model, distance);
     }


### PR DESCRIPTION
There is no training phase in KNN. The train() method just prepares the
data structure so that the algorithm can be applied. Do that in the
constructor instead.

BREAKING CHANGES:
The train method has been removed. Instead the arguments must be passed
to the KNN constructor.