### PR TITLE
in README, use "train_dataset" and "test_dataset" instead of just "dataset"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ var train_dataset = [
   [2, 1, 2]
 ];
 var train_labels = [0, 0, 0, 1, 1, 1];
-var knn = new KNN(train_dataset, train__labels);
+var knn = new KNN(train_dataset, train_labels, {k:2}); // consider 2 nearest neighbors for classification
+
 ```
 
 ### predict(newDataset)

--- a/README.md
+++ b/README.md
@@ -56,10 +56,21 @@ Predict the values of the dataset.
 **Example**:
 
 ```js
-var test_dataset = [[0, 0, 0], [2, 2, 2]];
+var test_dataset = [
+  [0.9, 0.9, 0.9],
+  [1.1, 1.1, 1.1],
+  [1.1, 1.1, 1.2],
+  [1.2, 1.2, 1.2],
+]
 
-var ans = knn.predict(test_dataset);
+var ans = knn.predict(test_dataset)
+
+console.log(ans)
+// classification result: 
+// ans = [ 0, 0, 1, 1 ]
 ```
+
+Based on the training data, the first two points of the test dataset are classified as "0" (type 0, perhaps), the third and fourth data points are classified as "1".
 
 ### toJSON()
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var train_dataset = [
   [2, 1, 2]
 ];
 var train_labels = [0, 0, 0, 1, 1, 1];
-var knn = new KNN(train_dataset, train_labels, {k:2}); // consider 2 nearest neighbors for classification
+var knn = new KNN(train_dataset, train_labels, {k:2}); // consider 2 nearest neighbors 
 
 ```
 
@@ -56,7 +56,7 @@ Predict the values of the dataset.
 **Example**:
 
 ```js
-var _test_dataset = [[0, 0, 0], [2, 2, 2]];
+var test_dataset = [[0, 0, 0], [2, 2, 2]];
 
 var ans = knn.predict(test_dataset);
 ```

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ var ans = knn.predict(test_dataset)
 console.log(ans)
 // classification result: 
 // ans = [ 0, 0, 1, 1 ]
+// Based on the training data, the first two points of the test dataset are classified as "0" (type 0, perhaps), the third and fourth data points are classified as "1".
+
 ```
 
-Based on the training data, the first two points of the test dataset are classified as "0" (type 0, perhaps), the third and fourth data points are classified as "1".
 
 ### toJSON()
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Instantiates the KNN algorithm.
 **Example**:
 
 ```js
-var dataset = [
+var train_dataset = [
   [0, 0, 0],
   [0, 1, 1],
   [1, 1, 0],
@@ -40,8 +40,8 @@ var dataset = [
   [1, 2, 2],
   [2, 1, 2]
 ];
-var predictions = [0, 0, 0, 1, 1, 1];
-var knn = new KNN(dataset, predictions);
+var train_labels = [0, 0, 0, 1, 1, 1];
+var knn = new KNN(train_dataset, train__labels);
 ```
 
 ### predict(newDataset)
@@ -55,9 +55,9 @@ Predict the values of the dataset.
 **Example**:
 
 ```js
-var dataset = [[0, 0, 0], [2, 2, 2]];
+var _test_dataset = [[0, 0, 0], [2, 2, 2]];
 
-var ans = knn.predict(dataset);
+var ans = knn.predict(test_dataset);
 ```
 
 ### toJSON()

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ var ans = knn.predict(test_dataset)
 console.log(ans)
 // classification result: 
 // ans = [ 0, 0, 1, 1 ]
-// Based on the training data, the first two points of the test dataset are classified as "0" (type 0, perhaps), the third and fourth data points are classified as "1".
+// Based on the training data, the first two points of the test dataset are classified as "0" (type 0, perhaps), 
+// the third and fourth data points are classified as "1".
 
 ```
 


### PR DESCRIPTION
I am not really fixing a bug here nor am I submitting an enhancement of the algorithm code.

The only thing I tried was to improve the README file a bit. On my first encounter, on my first reading of the README file, I was really confused about the usage of the variable name "dataset". So I renamed the variable to "train_dataset" and "test_dataset" respectively.

Also I have added a sentence with an interpretation of the toy example given.

That is all